### PR TITLE
feat(lock_job): populate last_error column on job lock

### DIFF
--- a/que.go
+++ b/que.go
@@ -192,10 +192,6 @@ type queryable interface {
 	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
 	Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
 	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
-
-	//Exec(ctx context.Context, sql string, arguments ...any) (commandTag pgconn.CommandTag, err error)
-	//Query(ctx context.Context, sql string, args ...any) (Rows, error)
-	//QueryRow(ctx context.Context, sql string, args ...any) Row
 }
 
 // Maximum number of loop iterations in LockJob before giving up.  This is to
@@ -239,6 +235,7 @@ func (c *Client) LockJob(ctx context.Context, queue string) (*Job, error) {
 			&j.Type,
 			&j.Args,
 			&j.ErrorCount,
+			&j.LastError,
 		)
 		if err != nil {
 			conn.Release()

--- a/sql.go
+++ b/sql.go
@@ -54,7 +54,7 @@ WITH RECURSIVE jobs AS (
     ) AS t1
   )
 )
-SELECT queue, priority, run_at, job_id, job_class, args, error_count
+SELECT queue, priority, run_at, job_id, job_class, args, error_count, last_error
 FROM jobs
 WHERE locked
 LIMIT 1


### PR DESCRIPTION
A duplicate of https://github.com/bgentry/que-go/pull/33. I'm using this in service and I need that last error column.